### PR TITLE
Go quip patch

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -1,16 +1,69 @@
 package quip
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
 )
 
-type Blob []byte
+type Blob struct {
+	ID  string
+	URL string
+}
 
-func (q *Client) GetBlob(blobId, threadId string) (Blob, error) {
+// XXX Return *Blob instead
+func (q *Client) GetBlob(blobId, threadId string) ([]byte, error) {
 	path := fmt.Sprintf("blob/%s/%s", threadId, blobId)
 	resp, err := q.getJson(q.apiUrlResource(path), map[string]string{})
+	return resp, err
+}
+
+func (q *Client) NewBlob(path string, threadId string) (*Blob, error) {
+
+	// Open file
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	defer file.Close()
+
+	// Create form file param
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	part, err := w.CreateFormFile("blob", file.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy file to form param
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Close writer
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("blob/%s", threadId)
+	req, err := http.NewRequest("POST", q.apiUrlResource(endpoint), &b)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := q.doRequest(req, 1)
+	if err != nil {
+		return nil, err
+	}
+	var blob Blob
+	if err := json.Unmarshal(resp, &blob); err != nil {
+		return nil, err
+	}
+	return &blob, nil
 }

--- a/blob.go
+++ b/blob.go
@@ -1,0 +1,16 @@
+package quip
+
+import (
+	"fmt"
+)
+
+type Blob []byte
+
+func (q *Client) GetBlob(blobId, threadId string) (Blob, error) {
+	path := fmt.Sprintf("blob/%s/%s", threadId, blobId)
+	resp, err := q.getJson(q.apiUrlResource(path), map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/folders.go
+++ b/folders.go
@@ -1,23 +1,21 @@
 package quip
 
 import (
-	"fmt"
+	"encoding/json"
 	"strings"
-
-	"github.com/mitchellh/mapstructure"
 )
 
 type Folder struct {
 	Info struct {
 		Id          string
 		Title       string
-		CreatedUsec int `mapstructure:"created_usec"`
-		UpdatedUsec int `mapstructure:"updated_usec"`
-		Color       int
-		ParentId    string `mapstructure:"parent_id"`
-	} `mapstructure:"folder"`
+		CreatedUsec int `json:"created_usec"`
+		UpdatedUsec int `json:"updated_usec"`
+		Color       string
+		ParentId    string `json:"parent_id"`
+	} `json:"folder"`
 
-	MemberIds []string `mapstructure:"member_ids"`
+	MemberIds []string `json:"member_ids"`
 	Children  []map[string]string
 }
 
@@ -46,73 +44,77 @@ type NewFolderParams struct {
 	MemberIds []string
 }
 
-func (q *Client) GetFolder(params *GetFolderParams) *Folder {
+func (q *Client) GetFolder(params *GetFolderParams) (*Folder, error) {
 	required(params.Id, "Id is required for /folder/id")
 
-	resp := q.getJson(apiUrlResource("folders/"+params.Id), map[string]string{})
-	parsed := parseJsonObject(resp)
-
-	return hydrateFolder(parsed)
+	resp, err := q.getJson(apiUrlResource("folders/"+params.Id), map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	var folder Folder
+	if err := json.Unmarshal(resp, &folder); err != nil {
+		return nil, err
+	}
+	return &folder, nil
 }
 
-func (q *Client) GetFolders(params *GetFoldersParams) []*Folder {
+func (q *Client) GetFolders(params *GetFoldersParams) ([]*Folder, error) {
 	required(params.Ids, "Ids is required for /folder/ids")
 
-	resp := q.getJson(apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
-	parsed := parseJsonObject(resp)
-
-	return hydrateFolders(parsed)
+	resp, _ := q.getJson(apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
+	var folders []*Folder
+	if err := json.Unmarshal(resp, folders); err != nil {
+		return nil, err
+	}
+	return folders, nil
 }
 
-func (q *Client) NewFolder(params *NewFolderParams) *Folder {
+func (q *Client) NewFolder(params *NewFolderParams) (*Folder, error) {
 	requestParams := make(map[string]string)
 	setRequired(params.Title, "title", &requestParams, "Title is required for /folders/new")
 	setOptional(params.ParentId, "parent_id", &requestParams)
 	setOptional(params.Color, "color", &requestParams)
 	setOptional(params.MemberIds, "member_ids", &requestParams)
 
-	resp := q.postJson(apiUrlResource("folders/new"), requestParams)
-	parsed := parseJsonObject(resp)
-
-	fmt.Println(string(resp))
-
-	return hydrateFolder(parsed)
+	resp, err := q.postJson(apiUrlResource("folders/new"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var folder Folder
+	if err := json.Unmarshal(resp, &folder); err != nil {
+		return nil, err
+	}
+	return &folder, err
 }
 
-func (q *Client) AddFolderMembers(params *AddFolderMembersParams) *Folder {
+func (q *Client) AddFolderMembers(params *AddFolderMembersParams) (*Folder, error) {
 	requestParams := make(map[string]string)
 	setRequired(params.FolderId, "folder_id", &requestParams, "FolderId is required for /folder/add-members")
 	setRequired(params.MemberIds, "member_ids", &requestParams, "MemberIds is required for /folder/add-members")
 
-	resp := q.postJson(apiUrlResource("folders/add-members"), requestParams)
-	parsed := parseJsonObject(resp)
-
-	return hydrateFolder(parsed)
+	resp, err := q.postJson(apiUrlResource("folders/add-members"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var folder Folder
+	if err := json.Unmarshal(resp, &folder); err != nil {
+		return nil, err
+	}
+	return &folder, err
 }
 
-func (q *Client) RemoveFolderMembers(params *RemoveFolderMembersParams) *Folder {
+func (q *Client) RemoveFolderMembers(params *RemoveFolderMembersParams) (*Folder, error) {
 	requestParams := make(map[string]string)
 	setRequired(params.FolderId, "folder_id", &requestParams, "FolderId is required for /folder/remove-members")
 	setRequired(params.MemberIds, "member_ids", &requestParams, "MemberIds is required for /folder/remove-members")
 
-	resp := q.postJson(apiUrlResource("folders/remove-members"), requestParams)
-	parsed := parseJsonObject(resp)
-
-	return hydrateFolder(parsed)
-}
-
-func hydrateFolder(resp interface{}) *Folder {
-	var folder Folder
-	mapstructure.Decode(resp, &folder)
-	return &folder
-}
-
-func hydrateFolders(resp map[string]interface{}) []*Folder {
-	folders := make([]*Folder, 0, len(resp))
-
-	for _, body := range resp {
-		folders = append(folders, hydrateFolder(body))
+	resp, err := q.postJson(apiUrlResource("folders/remove-members"), requestParams)
+	if err != nil {
+		return nil, err
 	}
-
-	return folders
+	var folder Folder
+	if err := json.Unmarshal(resp, &folder); err != nil {
+		return nil, err
+	}
+	return &folder, err
 }

--- a/folders.go
+++ b/folders.go
@@ -1,7 +1,6 @@
 package quip
 
 import (
-	"encoding/json"
 	"strings"
 )
 
@@ -52,7 +51,7 @@ func (q *Client) GetFolder(params *GetFolderParams) (*Folder, error) {
 		return nil, err
 	}
 	var folder Folder
-	if err := json.Unmarshal(resp, &folder); err != nil {
+	if err := unmarshal(resp, &folder); err != nil {
 		return nil, err
 	}
 	return &folder, nil
@@ -74,7 +73,7 @@ func (q *Client) GetFolders(params *GetFoldersParams) ([]*Folder, error) {
 	}
 
 	var folderMap map[string]*Folder
-	if err := json.Unmarshal(resp, &folderMap); err != nil {
+	if err := unmarshal(resp, &folderMap); err != nil {
 		return nil, err
 	}
 
@@ -96,7 +95,7 @@ func (q *Client) NewFolder(params *NewFolderParams) (*Folder, error) {
 		return nil, err
 	}
 	var folder Folder
-	if err := json.Unmarshal(resp, &folder); err != nil {
+	if err := unmarshal(resp, &folder); err != nil {
 		return nil, err
 	}
 	return &folder, err
@@ -112,7 +111,7 @@ func (q *Client) AddFolderMembers(params *AddFolderMembersParams) (*Folder, erro
 		return nil, err
 	}
 	var folder Folder
-	if err := json.Unmarshal(resp, &folder); err != nil {
+	if err := unmarshal(resp, &folder); err != nil {
 		return nil, err
 	}
 	return &folder, err
@@ -128,7 +127,7 @@ func (q *Client) RemoveFolderMembers(params *RemoveFolderMembersParams) (*Folder
 		return nil, err
 	}
 	var folder Folder
-	if err := json.Unmarshal(resp, &folder); err != nil {
+	if err := unmarshal(resp, &folder); err != nil {
 		return nil, err
 	}
 	return &folder, err

--- a/folders.go
+++ b/folders.go
@@ -60,11 +60,26 @@ func (q *Client) GetFolder(params *GetFolderParams) (*Folder, error) {
 
 func (q *Client) GetFolders(params *GetFoldersParams) ([]*Folder, error) {
 	required(params.Ids, "Ids is required for /folder/ids")
-
-	resp, _ := q.getJson(q.apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
 	var folders []*Folder
-	if err := json.Unmarshal(resp, folders); err != nil {
+
+	if len(params.Ids) == 0 { // nothing to do
+		return folders, nil
+	}
+
+	resp, err := q.getJson(q.apiUrlResource("folders/"), map[string]string{
+		"ids": strings.Join(params.Ids, ","),
+	})
+	if err != nil {
 		return nil, err
+	}
+
+	var folderMap map[string]*Folder
+	if err := json.Unmarshal(resp, &folderMap); err != nil {
+		return nil, err
+	}
+
+	for _, f := range folderMap {
+		folders = append(folders, f)
 	}
 	return folders, nil
 }

--- a/folders.go
+++ b/folders.go
@@ -47,7 +47,7 @@ type NewFolderParams struct {
 func (q *Client) GetFolder(params *GetFolderParams) (*Folder, error) {
 	required(params.Id, "Id is required for /folder/id")
 
-	resp, err := q.getJson(apiUrlResource("folders/"+params.Id), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("folders/"+params.Id), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (q *Client) GetFolder(params *GetFolderParams) (*Folder, error) {
 func (q *Client) GetFolders(params *GetFoldersParams) ([]*Folder, error) {
 	required(params.Ids, "Ids is required for /folder/ids")
 
-	resp, _ := q.getJson(apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
+	resp, _ := q.getJson(q.apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
 	var folders []*Folder
 	if err := json.Unmarshal(resp, folders); err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (q *Client) NewFolder(params *NewFolderParams) (*Folder, error) {
 	setOptional(params.Color, "color", &requestParams)
 	setOptional(params.MemberIds, "member_ids", &requestParams)
 
-	resp, err := q.postJson(apiUrlResource("folders/new"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("folders/new"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (q *Client) AddFolderMembers(params *AddFolderMembersParams) (*Folder, erro
 	setRequired(params.FolderId, "folder_id", &requestParams, "FolderId is required for /folder/add-members")
 	setRequired(params.MemberIds, "member_ids", &requestParams, "MemberIds is required for /folder/add-members")
 
-	resp, err := q.postJson(apiUrlResource("folders/add-members"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("folders/add-members"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (q *Client) RemoveFolderMembers(params *RemoveFolderMembersParams) (*Folder
 	setRequired(params.FolderId, "folder_id", &requestParams, "FolderId is required for /folder/remove-members")
 	setRequired(params.MemberIds, "member_ids", &requestParams, "MemberIds is required for /folder/remove-members")
 
-	resp, err := q.postJson(apiUrlResource("folders/remove-members"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("folders/remove-members"), requestParams)
 	if err != nil {
 		return nil, err
 	}

--- a/folders.go
+++ b/folders.go
@@ -15,7 +15,24 @@ type Folder struct {
 	} `json:"folder"`
 
 	MemberIds []string `json:"member_ids"`
-	Children  []map[string]string
+	Children  []FolderItem
+}
+
+type FolderItem struct {
+	// Either FolderID or ThreadID will be set but not both
+	FolderID   string `json:"folder_id"`
+	ThreadID   string `json:"thread_id"`
+	Restricted bool   `json:"restricted"`
+}
+
+func (fi FolderItem) ItemKindID() (string, string) {
+	if fi.FolderID != "" {
+		return "folder_id", fi.FolderID
+	}
+	if fi.ThreadID != "" {
+		return "thread_id", fi.ThreadID
+	}
+	return "unknown", ""
 }
 
 type GetFolderParams struct {

--- a/messages.go
+++ b/messages.go
@@ -30,7 +30,7 @@ func (q *Client) GetRecentMessages(params *GetRecentMessagesParams) ([]*Message,
 	setOptional(params.Count, "count", &requestParams)
 	setOptional(params.MaxUpdatedUsec, "max_updated_usec", &requestParams)
 
-	resp, err := q.getJson(apiUrlResource("messages/"+params.ThreadId), requestParams)
+	resp, err := q.getJson(q.apiUrlResource("messages/"+params.ThreadId), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (q *Client) NewMessage(params *NewMessageParams) (*Message, error) {
 
 	setOptional(params.Silent, "silent", &requestParams)
 
-	resp, err := q.postJson(apiUrlResource("messages/new"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("messages/new"), requestParams)
 	if err != nil {
 		return nil, err
 	}

--- a/quip.go
+++ b/quip.go
@@ -7,6 +7,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
+
+	"github.com/beefsack/go-rate"
 )
 
 type Client struct {
@@ -15,6 +18,7 @@ type Client struct {
 	clientSecret string
 	redirectUri  string
 	apiUrl       string
+	throttle     *rate.RateLimiter
 }
 
 func NewClient(accessToken string) *Client {
@@ -37,6 +41,14 @@ func NewClientOAuth(accessToken string, clientId string, clientSecret string, re
 
 func (q *Client) SetApiUrl(url string) {
 	q.apiUrl = url
+}
+
+func (q *Client) Throttle(interval time.Duration) {
+	if interval == 0 {
+		q.throttle = nil
+		return
+	}
+	q.throttle = rate.New(1, interval)
 }
 
 func (q *Client) postJson(resource string, params map[string]string) ([]byte, error) {
@@ -71,6 +83,11 @@ func (q *Client) getJson(resource string, params map[string]string) ([]byte, err
 func (q *Client) doRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	req.Header.Set("Authorization", "Bearer "+q.accessToken)
+
+	if q.throttle != nil {
+		q.throttle.Wait()
+	}
+
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/quip.go
+++ b/quip.go
@@ -57,7 +57,7 @@ func (q *Client) Throttle(interval time.Duration) {
 func (q *Client) postJson(resource string, params map[string]string) ([]byte, error) {
 	req, err := http.NewRequest("POST", resource, mapToQueryString(params))
 	if err != nil {
-		log.Fatal("Bad url: " + resource)
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 

--- a/quip.go
+++ b/quip.go
@@ -107,8 +107,8 @@ func (q *Client) doRequest(req *http.Request, attempt int) ([]byte, error) {
 	// retry_rate_limit in https://github.com/ConsenSys/quip-projects/blob/master/quip.py
 	// "250 calls per hour/15 per minute" https://twitter.com/QuipSupport/status/527965994761744384
 	// Seems to give a 15s wait first then 44s waits for every ~48 rapid requests.
-	if res.StatusCode == http.StatusServiceUnavailable && (                  // 503
-	req.Method == "GET" || req.Method == "DELETE" || req.Method == "HEAD") { // idempotent
+	if res.StatusCode == http.StatusServiceUnavailable && (                                          // 503
+	req.Method == "GET" || req.Method == "POST" || req.Method == "DELETE" || req.Method == "HEAD") { // idempotent
 		delay := 5 * time.Second // default
 		resetRateLimit := res.Header.Get("X-RateLimit-Reset")
 		if len(resetRateLimit) == 0 {

--- a/quip.go
+++ b/quip.go
@@ -9,20 +9,18 @@ import (
 	"strings"
 )
 
-const (
-	BASE_API_URL = "https://platform.quip.com"
-)
-
 type Client struct {
 	accessToken  string
 	clientId     string
 	clientSecret string
 	redirectUri  string
+	apiUrl       string
 }
 
 func NewClient(accessToken string) *Client {
 	return &Client{
 		accessToken: accessToken,
+		apiUrl:      "https://platform.quip.com",
 	}
 }
 
@@ -33,7 +31,12 @@ func NewClientOAuth(accessToken string, clientId string, clientSecret string, re
 		clientId:     clientId,
 		clientSecret: clientSecret,
 		redirectUri:  redirectUri,
+		apiUrl:       "https://platform.quip.com",
 	}
+}
+
+func (q *Client) SetApiUrl(url string) {
+	q.apiUrl = url
 }
 
 func (q *Client) postJson(resource string, params map[string]string) ([]byte, error) {
@@ -85,8 +88,8 @@ func mapToQueryString(params map[string]string) *strings.Reader {
 	return strings.NewReader(body.Encode())
 }
 
-func apiUrlResource(resource string) string {
-	return BASE_API_URL + "/1/" + resource
+func (q *Client) apiUrlResource(resource string) string {
+	return q.apiUrl + "/1/" + resource
 }
 
 func required(val interface{}, message string) {

--- a/quip.go
+++ b/quip.go
@@ -2,6 +2,7 @@ package quip
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -92,8 +93,12 @@ func (q *Client) doRequest(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		return []byte{}, fmt.Errorf("%s, in response to %s %s", res.Status, req.Method, req.URL)
+	}
+
 	return ioutil.ReadAll(res.Body)
 }
 

--- a/quip.go
+++ b/quip.go
@@ -117,7 +117,7 @@ func (q *Client) doRequest(req *http.Request, attempt int) ([]byte, error) {
 		log.Printf("Asked to halt for %s...\n", until.Round(time.Second).String())
 		time.Sleep(until)
 		attempt = attempt + 1
-		q.doRequest(req, attempt)
+		return q.doRequest(req, attempt)
 	}
 
 	if res.StatusCode >= 400 {

--- a/quip.go
+++ b/quip.go
@@ -36,7 +36,7 @@ func NewClientOAuth(accessToken string, clientId string, clientSecret string, re
 	}
 }
 
-func (q *Client) postJson(resource string, params map[string]string) []byte {
+func (q *Client) postJson(resource string, params map[string]string) ([]byte, error) {
 	req, err := http.NewRequest("POST", resource, mapToQueryString(params))
 	if err != nil {
 		log.Fatal("Bad url: " + resource)
@@ -46,10 +46,10 @@ func (q *Client) postJson(resource string, params map[string]string) []byte {
 	return q.doRequest(req)
 }
 
-func (q *Client) getJson(resource string, params map[string]string) []byte {
+func (q *Client) getJson(resource string, params map[string]string) ([]byte, error) {
 	qs, err := ioutil.ReadAll(mapToQueryString(params))
 	if err != nil {
-		log.Fatal("Malformed query params %v", params)
+		return nil, err
 	}
 
 	queryString := string(qs)
@@ -59,23 +59,22 @@ func (q *Client) getJson(resource string, params map[string]string) []byte {
 
 	req, err := http.NewRequest("GET", resource, nil)
 	if err != nil {
-		log.Fatal("Bad url: " + resource)
+		return nil, err
 	}
 
 	return q.doRequest(req)
 }
 
-func (q *Client) doRequest(req *http.Request) []byte {
+func (q *Client) doRequest(req *http.Request) ([]byte, error) {
 	client := &http.Client{}
 	req.Header.Set("Authorization", "Bearer "+q.accessToken)
 	res, err := client.Do(req)
 	if err != nil {
-		// TODO: handle API errors here
+		return nil, err
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
-	return body
+	return ioutil.ReadAll(res.Body)
 }
 
 func mapToQueryString(params map[string]string) *strings.Reader {

--- a/quip.go
+++ b/quip.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/beefsack/go-rate"
 )
 
 type Client struct {
@@ -21,7 +19,6 @@ type Client struct {
 	clientSecret string
 	redirectUri  string
 	apiUrl       string
-	throttle     *rate.RateLimiter
 }
 
 func NewClient(accessToken string) *Client {
@@ -44,14 +41,6 @@ func NewClientOAuth(accessToken string, clientId string, clientSecret string, re
 
 func (q *Client) SetApiUrl(url string) {
 	q.apiUrl = url
-}
-
-func (q *Client) Throttle(interval time.Duration) {
-	if interval == 0 {
-		q.throttle = nil
-		return
-	}
-	q.throttle = rate.New(1, interval)
 }
 
 func (q *Client) postJson(resource string, params map[string]string) ([]byte, error) {
@@ -92,10 +81,6 @@ func (q *Client) doRequest(req *http.Request, attempt int) ([]byte, error) {
 
 	client := &http.Client{}
 	req.Header.Set("Authorization", "Bearer "+q.accessToken)
-
-	if q.throttle != nil {
-		q.throttle.Wait()
-	}
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/threads.go
+++ b/threads.go
@@ -74,15 +74,27 @@ func (q *Client) GetThread(id string) (*Thread, error) {
 }
 
 func (q *Client) GetThreads(ids []string) ([]*Thread, error) {
-	qid := strings.Join(ids, ",")
-	resp, err := q.getJson(q.apiUrlResource("threads/?ids="+qid), map[string]string{})
+	var threads []*Thread
+
+	if len(ids) == 0 {
+		return threads, nil
+	}
+
+	resp, err := q.getJson(q.apiUrlResource("threads/"), map[string]string{
+		"ids": strings.Join(ids, ","),
+	})
 	if err != nil {
 		return nil, err
 	}
-	var threads []*Thread
-	if err := json.Unmarshal(resp, &threads); err != nil {
+
+	var threadMap map[string]*Thread
+	if err := json.Unmarshal(resp, &threadMap); err != nil {
 		return nil, err
 	}
+	for _, t := range threadMap {
+		threads = append(threads, t)
+	}
+
 	return threads, nil
 }
 

--- a/threads.go
+++ b/threads.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+const (
+	APPEND          = "0"
+	PREPEND         = "1"
+	AFTER_SECTION   = "2"
+	BEFORE_SECTION  = "3"
+	REPLACE_SECTION = "4"
+	DELETE_SECTION  = "5"
+)
+
 type ThreadSharing struct {
 	CompanyID   string `json:"company_id"`
 	CompanyMode string `json:"company_mode"`
@@ -47,7 +56,7 @@ type EditDocumentParams struct {
 	Content   string
 	Format    string
 	Location  string
-	MemberIds []string
+	SectionId string
 }
 
 type AddMembersParams struct {
@@ -135,12 +144,12 @@ func (q *Client) NewDocument(params *NewDocumentParams) (*Thread, error) {
 
 func (q *Client) EditDocument(params *EditDocumentParams) (*Thread, error) {
 	requestParams := make(map[string]string)
-	required(params.Content, "Content is required for /edit-document")
-	requestParams["content"] = params.Content
+	setRequired(params.Content, "content", &requestParams, "Content is required for /edit-document")
+	setRequired(params.ThreadId, "thread_id", &requestParams, "Thread ID is required for /edit-document")
 
 	setOptional(params.Format, "format", &requestParams)
 	setOptional(params.Location, "location", &requestParams)
-	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
+	setOptional(params.SectionId, "section_id", &requestParams)
 
 	resp, err := q.postJson(q.apiUrlResource("threads/edit-document"), requestParams)
 	if err != nil {

--- a/threads.go
+++ b/threads.go
@@ -2,7 +2,6 @@ package quip
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -123,7 +122,6 @@ func (q *Client) NewDocument(params *NewDocumentParams) (*Thread, error) {
 	setOptional(params.Title, "title", &requestParams)
 	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
 
-	fmt.Println(requestParams)
 	resp, err := q.postJson(q.apiUrlResource("threads/new-document"), requestParams)
 	if err != nil {
 		return nil, err

--- a/threads.go
+++ b/threads.go
@@ -62,7 +62,7 @@ type RemoveMembersParams struct {
 }
 
 func (q *Client) GetThread(id string) (*Thread, error) {
-	resp, err := q.getJson(apiUrlResource("threads/"+id), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("threads/"+id), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (q *Client) GetThread(id string) (*Thread, error) {
 
 func (q *Client) GetThreads(ids []string) ([]*Thread, error) {
 	qid := strings.Join(ids, ",")
-	resp, err := q.getJson(apiUrlResource("threads/?ids="+qid), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("threads/?ids="+qid), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (q *Client) GetRecentThreads(params *GetRecentThreadsParams) ([]*Thread, er
 	setOptional(params.Count, "count", &requestParams)
 	setOptional(params.MaxUpdatedUsec, "max_updated_usec", &requestParams)
 
-	resp, err := q.getJson(apiUrlResource("threads/recent"), requestParams)
+	resp, err := q.getJson(q.apiUrlResource("threads/recent"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (q *Client) NewDocument(params *NewDocumentParams) (*Thread, error) {
 	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
 
 	fmt.Println(requestParams)
-	resp, err := q.postJson(apiUrlResource("threads/new-document"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("threads/new-document"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (q *Client) EditDocument(params *EditDocumentParams) (*Thread, error) {
 	setOptional(params.Location, "location", &requestParams)
 	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
 
-	resp, err := q.postJson(apiUrlResource("threads/edit-document"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("threads/edit-document"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (q *Client) AddMembers(params *AddMembersParams) (*Thread, error) {
 	requestParams["thread_id"] = params.ThreadId
 	requestParams["member_ids"] = strings.Join(params.MemberIds, ",")
 
-	resp, err := q.postJson(apiUrlResource("threads/add-members"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("threads/add-members"), requestParams)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (q *Client) RemoveMembers(params *RemoveMembersParams) (*Thread, error) {
 	requestParams["thread_id"] = params.ThreadId
 	requestParams["member_ids"] = strings.Join(params.MemberIds, ",")
 
-	resp, err := q.postJson(apiUrlResource("threads/remove-members"), requestParams)
+	resp, err := q.postJson(q.apiUrlResource("threads/remove-members"), requestParams)
 	if err != nil {
 		return nil, err
 	}

--- a/threads.go
+++ b/threads.go
@@ -1,18 +1,34 @@
 package quip
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/mitchellh/mapstructure"
 )
 
+type ThreadSharing struct {
+	CompanyID   string `json:"company_id"`
+	CompanyMode string `json:"company_mode"`
+}
+
+type ThreadDetails struct {
+	ID          string
+	AuthorID    string `json:"author_id"`
+	ThreadClass string `json:"thread_class"`
+	Created     int64  `json:"created_usec"`
+	Updated     int64  `json:"updated_usec"`
+	Title       string
+	Link        string
+	Type        string
+	Sharing     ThreadSharing
+}
+
 type Thread struct {
-	ExpandedUserIds []string `mapstructure:"expanded_user_ids"`
-	UserIds         []string `mapstructure:"user_ids"`
-	SharedFolderIds []string `mapstructure:"shared_folder_ids"`
+	ExpandedUserIds []string `json:"expanded_user_ids"`
+	UserIds         []string `json:"user_ids"`
+	SharedFolderIds []string `json:"shared_folder_ids"`
 	Html            string
-	Thread          map[string]string
+	Thread          ThreadDetails
 }
 
 type GetRecentThreadsParams struct {
@@ -45,31 +61,49 @@ type RemoveMembersParams struct {
 	MemberIds []string
 }
 
-func (q *Client) GetThread(id string) *Thread {
-	resp := q.getJson(apiUrlResource("threads/"+id), map[string]string{})
-	parsed := parseJsonObject(resp)
-	return hydrateThread(parsed)
+func (q *Client) GetThread(id string) (*Thread, error) {
+	resp, err := q.getJson(apiUrlResource("threads/"+id), map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	var thread Thread
+	if err := json.Unmarshal(resp, &thread); err != nil {
+		return nil, err
+	}
+	return &thread, nil
 }
 
-func (q *Client) GetThreads(ids []string) []*Thread {
+func (q *Client) GetThreads(ids []string) ([]*Thread, error) {
 	qid := strings.Join(ids, ",")
-	resp := q.getJson(apiUrlResource("threads/?ids="+qid), map[string]string{})
-	parsed := parseJsonObject(resp)
-	return hydrateThreads(parsed)
+	resp, err := q.getJson(apiUrlResource("threads/?ids="+qid), map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	var threads []*Thread
+	if err := json.Unmarshal(resp, &threads); err != nil {
+		return nil, err
+	}
+	return threads, nil
 }
 
-func (q *Client) GetRecentThreads(params *GetRecentThreadsParams) []*Thread {
+func (q *Client) GetRecentThreads(params *GetRecentThreadsParams) ([]*Thread, error) {
 	requestParams := make(map[string]string)
 
 	setOptional(params.Count, "count", &requestParams)
 	setOptional(params.MaxUpdatedUsec, "max_updated_usec", &requestParams)
 
-	resp := q.getJson(apiUrlResource("threads/recent"), requestParams)
-	parsed := parseJsonObject(resp)
-	return hydrateThreads(parsed)
+	resp, err := q.getJson(apiUrlResource("threads/recent"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var threads []*Thread
+	if err := json.Unmarshal(resp, &threads); err != nil {
+		return nil, err
+	}
+	return threads, nil
 }
 
-func (q *Client) NewDocument(params *NewDocumentParams) *Thread {
+func (q *Client) NewDocument(params *NewDocumentParams) (*Thread, error) {
 	requestParams := make(map[string]string)
 
 	setRequired(params.Content, "content", &requestParams, "Content is required for /new-document")
@@ -78,12 +112,18 @@ func (q *Client) NewDocument(params *NewDocumentParams) *Thread {
 	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
 
 	fmt.Println(requestParams)
-	resp := q.postJson(apiUrlResource("threads/new-document"), requestParams)
-	parsed := parseJsonObject(resp)
-	return hydrateThread(parsed)
+	resp, err := q.postJson(apiUrlResource("threads/new-document"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var thread Thread
+	if err := json.Unmarshal(resp, &thread); err != nil {
+		return nil, err
+	}
+	return &thread, nil
 }
 
-func (q *Client) EditDocument(params *EditDocumentParams) *Thread {
+func (q *Client) EditDocument(params *EditDocumentParams) (*Thread, error) {
 	requestParams := make(map[string]string)
 	required(params.Content, "Content is required for /edit-document")
 	requestParams["content"] = params.Content
@@ -92,12 +132,18 @@ func (q *Client) EditDocument(params *EditDocumentParams) *Thread {
 	setOptional(params.Location, "location", &requestParams)
 	setOptional(strings.Join(params.MemberIds, ","), "member_ids", &requestParams)
 
-	resp := q.postJson(apiUrlResource("threads/edit-document"), requestParams)
-
-	return hydrateThread(resp)
+	resp, err := q.postJson(apiUrlResource("threads/edit-document"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var thread Thread
+	if err := json.Unmarshal(resp, &thread); err != nil {
+		return nil, err
+	}
+	return &thread, nil
 }
 
-func (q *Client) AddMembers(params *AddMembersParams) *Thread {
+func (q *Client) AddMembers(params *AddMembersParams) (*Thread, error) {
 	requestParams := make(map[string]string)
 	required(params.ThreadId, "ThreadId is required for /add-members")
 	required(params.MemberIds, "MemberIds is required for /add-members")
@@ -105,12 +151,18 @@ func (q *Client) AddMembers(params *AddMembersParams) *Thread {
 	requestParams["thread_id"] = params.ThreadId
 	requestParams["member_ids"] = strings.Join(params.MemberIds, ",")
 
-	resp := q.postJson(apiUrlResource("threads/add-members"), requestParams)
-	parsed := parseJsonObject(resp)
-	return hydrateThread(parsed)
+	resp, err := q.postJson(apiUrlResource("threads/add-members"), requestParams)
+	if err != nil {
+		return nil, err
+	}
+	var thread Thread
+	if err := json.Unmarshal(resp, &thread); err != nil {
+		return nil, err
+	}
+	return &thread, nil
 }
 
-func (q *Client) RemoveMembers(params *RemoveMembersParams) *Thread {
+func (q *Client) RemoveMembers(params *RemoveMembersParams) (*Thread, error) {
 	requestParams := make(map[string]string)
 	required(params.ThreadId, "ThreadId is required for /remove-members")
 	required(params.MemberIds, "MemberIds is required for /remove-members")
@@ -118,23 +170,13 @@ func (q *Client) RemoveMembers(params *RemoveMembersParams) *Thread {
 	requestParams["thread_id"] = params.ThreadId
 	requestParams["member_ids"] = strings.Join(params.MemberIds, ",")
 
-	resp := q.postJson(apiUrlResource("threads/remove-members"), requestParams)
-	parsed := parseJsonObject(resp)
-	return hydrateThread(parsed)
-}
-
-func hydrateThread(resp interface{}) *Thread {
-	var thread Thread
-	mapstructure.Decode(resp, &thread)
-	return &thread
-}
-
-func hydrateThreads(resp map[string]interface{}) []*Thread {
-	threads := make([]*Thread, 0, len(resp))
-
-	for _, body := range resp {
-		threads = append(threads, hydrateThread(body))
+	resp, err := q.postJson(apiUrlResource("threads/remove-members"), requestParams)
+	if err != nil {
+		return nil, err
 	}
-
-	return threads
+	var thread Thread
+	if err := json.Unmarshal(resp, &thread); err != nil {
+		return nil, err
+	}
+	return &thread, nil
 }

--- a/users.go
+++ b/users.go
@@ -30,7 +30,10 @@ func (q *Client) GetUser(params *GetUserParams) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	parsed := parseJsonObject(resp)
+	parsed, err := parseJsonObject(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	return hydrateUser(parsed)
 }
@@ -42,7 +45,10 @@ func (q *Client) GetUsers(params *GetUsersParams) ([]*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	parsed := parseJsonObject(resp)
+	parsed, err := parseJsonObject(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	return hydrateUsersMap(parsed)
 }
@@ -52,7 +58,10 @@ func (q *Client) GetContacts() ([]*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	parsed := parseJsonArray(resp)
+	parsed, err := parseJsonArray(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	return hydrateUsersArray(parsed)
 }
@@ -62,7 +71,10 @@ func (q *Client) GetAuthenticatedUser() (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	parsed := parseJsonObject(resp)
+	parsed, err := parseJsonObject(resp)
+	if err != nil {
+		return nil, err
+	}
 
 	return hydrateUser(parsed)
 }

--- a/users.go
+++ b/users.go
@@ -26,7 +26,7 @@ type GetUsersParams struct {
 func (q *Client) GetUser(params *GetUserParams) (*User, error) {
 	required(params.Id, "Id is required for /users/id")
 
-	resp, err := q.getJson(apiUrlResource("users/"+params.Id), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("users/"+params.Id), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (q *Client) GetUser(params *GetUserParams) (*User, error) {
 func (q *Client) GetUsers(params *GetUsersParams) ([]*User, error) {
 	required(params.Ids, "Ids is required for /users/ids")
 
-	resp, err := q.getJson(apiUrlResource("users/"+strings.Join(params.Ids, ",")), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("users/"+strings.Join(params.Ids, ",")), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (q *Client) GetUsers(params *GetUsersParams) ([]*User, error) {
 }
 
 func (q *Client) GetContacts() ([]*User, error) {
-	resp, err := q.getJson(apiUrlResource("users/contacts"), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("users/contacts"), map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (q *Client) GetContacts() ([]*User, error) {
 }
 
 func (q *Client) GetAuthenticatedUser() (*User, error) {
-	resp, err := q.getJson(apiUrlResource("users/current"), map[string]string{})
+	resp, err := q.getJson(q.apiUrlResource("users/current"), map[string]string{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi there, we've been using `go-quip` for a work project, and made some patches along the way. Here they all are in one pull request. I've summarized the changes into the following bullet points:

---

* New API endpoint wrapper functions:

  * GetBlob() - https://quip.com/dev/automation/documentation#blob-get

  * NewBlob() - https://quip.com/dev/automation/documentation#blob-post

---

* Replace mapstructure with native json marshaling/unmarshaling

---

* Handle errors, bubble errors to caller

---

* Replace BASE_API_URL with Client.SetApiUrl()
  * This allows custom URLs to be set. In my use case I'm dealing with an internal instance of Quip.
Otherwise Client will use default domain

---

* Support retires on HTTP request with delays
  * Retries triggered by http.StatusServiceUnavailable or http.StatusTooManyRequests
  * Delay defined by X-RateLimit-Set heade (POST)  or Retry-After header (GET)
  * Default to 5s delay if none found
  * Don't exceed Client.maxRateLimitDelay value
  * No docs for this on Quip API reference page, see comments for more details

---

* Add location constants for edit-document enpoint: https://quip.com/dev/automation/documentation#document-put
  * 0: APPEND - Append to the end of the document.
  * 1: PREPEND - Prepend to the beginning of the document.
  * 2: AFTER_SECTION - Insert after the section specified by section_id.
  * 3: BEFORE_SECTION - Insert before the section specified by section_id.
  * 4: REPLACE_SECTION - Delete the section specified by section_id and insert the new content at that location.
  * 5: DELETE_SECTION - Delete the section specified by section_id (no content required).

---

Majority of changes relate to error handling and using native json package. Feel free to ask any questions, and please let me know if there's anything I should do on my end.

Thanks!